### PR TITLE
Update delivery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bin/
+target/

--- a/.project
+++ b/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.sii.rental.parent</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1604702582421</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>

--- a/com.sii.rental.core/.classpath
+++ b/com.sii.rental.core/.classpath
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="lib" path="lib/rental.jar"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-14"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry exported="true" kind="lib" path="lib/rental.jar"/>
+	<classpathentry kind="src" path="src/"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/com.sii.rental.core/.project
+++ b/com.sii.rental.core/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.sii.rental.core</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/com.sii.rental.core/META-INF/MANIFEST.MF
+++ b/com.sii.rental.core/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Activator: com.sii.rental.core.RentalCoreActivator
 Bundle-Vendor: SII
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport
-Bundle-RequiredExecutionEnvironment: JavaSE-14
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: com.sii.rental.core
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: lib/rental.jar,

--- a/com.sii.rental.core/pom.xml
+++ b/com.sii.rental.core/pom.xml
@@ -9,7 +9,6 @@
 	</parent>
 
 	<artifactId>com.sii.rental.core</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	
 </project>

--- a/com.sii.rental.eap/.classpath
+++ b/com.sii.rental.eap/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-14"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/com.sii.rental.eap/.project
+++ b/com.sii.rental.eap/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.sii.rental.eap</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/com.sii.rental.eap/META-INF/MANIFEST.MF
+++ b/com.sii.rental.eap/META-INF/MANIFEST.MF
@@ -18,7 +18,7 @@ Require-Bundle: javax.inject;bundle-version="0.0.0",
  com.sii.rental.ui;bundle-version="1.0.0",
  org.eclipse.osgi.services,
  com.opcoach.e4.preferences.mainmenu
-Bundle-RequiredExecutionEnvironment: JavaSE-14
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: com.sii.rental.eap
 Import-Package: javax.annotation;version="0.0.0"
 Bundle-ActivationPolicy: lazy

--- a/com.sii.rental.repository/.project
+++ b/com.sii.rental.repository/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.sii.rental.repository</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/com.sii.rental.repository/pom.xml
+++ b/com.sii.rental.repository/pom.xml
@@ -8,7 +8,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>com.sii.rental.ui.feature</artifactId>
+	<artifactId>com.sii.rental.repository</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>eclipse-repository</packaging>
 	

--- a/com.sii.rental.repository/pom.xml
+++ b/com.sii.rental.repository/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
@@ -11,5 +12,29 @@
 	<artifactId>com.sii.rental.repository</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>eclipse-repository</packaging>
-	
+
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-director-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>materialize-products</id>
+						<goals>
+							<goal>materialize-products</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>archive-products</id>
+						<goals>
+							<goal>archive-products</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/com.sii.rental.repository/rental.product
+++ b/com.sii.rental.repository/rental.product
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product name="com.sii.rental.eap" uid="rental" id="com.sii.rental.eap.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="1.0.0.qualifier" useFeatures="true" includeLaunchers="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <programArgs>-consoleLog -clearPersistedState -perspective com.sii.rental.ui.perspective.rental
+      </programArgs>
+      <vmArgs>--enable-preview
+      </vmArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+   </launcherArgs>
+
+   <windowImages/>
+
+   <launcher name="rental">
+      <win useIco="false">
+         <bmp/>
+      </win>
+   </launcher>
+
+   <vm>
+      <macos include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-14</macos>
+   </vm>
+
+   <plugins>
+   </plugins>
+
+   <features>
+      <feature id="com.sii.rental.ui.feature" installMode="root"/>
+      <feature id="com.opcoach.e4.preferences.feature" installMode="root"/>
+      <feature id="org.eclipse.e4.rcp" installMode="root"/>
+   </features>
+
+   <configurations>
+      <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="0" />
+      <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+   </configurations>
+
+</product>

--- a/com.sii.rental.tp/.project
+++ b/com.sii.rental.tp/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.sii.rental.tp</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/com.sii.rental.tp/com.sii.rental.tp.target
+++ b/com.sii.rental.tp/com.sii.rental.tp.target
@@ -1,30 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Training RCP 4" sequenceNumber="1604672558">
+<target name="Training RCP 4" sequenceNumber="1604707150">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.platform.feature.group" version="4.15.0.v20200305-0155"/>
-      <unit id="org.eclipse.e4.rcp.feature.group" version="4.15.0.v20200304-0601"/>
+      <unit id="org.eclipse.platform.feature.group" version="4.17.0.v20200902-1800"/>
+      <unit id="org.eclipse.e4.rcp.feature.group" version="4.17.0.v20200831-1002"/>
       <unit id="org.eclipse.emf.databinding.feature.group" version="1.7.0.v20190323-1059"/>
-      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.700.v20200207-2156"/>
-      <unit id="org.eclipse.pde.junit.runtime" version="3.5.700.v20200116-1804"/>
-      <unit id="org.eclipse.jdt.junit5.runtime" version="1.0.800.v20200214-0716"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.900.v20200819-0940"/>
+      <unit id="org.eclipse.pde.junit.runtime" version="3.5.900.v20200810-0835"/>
+      <unit id="org.eclipse.jdt.junit5.runtime" version="1.0.1000.v20200720-0748"/>
       <unit id="org.junit.jupiter.api" version="5.6.0.v20200203-2009"/>
       <unit id="org.junit.jupiter.engine" version="5.6.0.v20200203-2009"/>
       <unit id="org.junit.jupiter.migrationsupport" version="5.6.0.v20200203-2009"/>
       <unit id="org.junit.jupiter.params" version="5.6.0.v20200203-2009"/>
       <unit id="org.junit.platform.commons" version="1.6.0.v20200203-2009"/>
-      <repository location="http://download.eclipse.org/releases/2020-03"/>
+      <repository location="http://download.eclipse.org/releases/2020-09"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="javax.annotation" version="1.3.5.v20200504-1837"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200831200620/repository"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.e4.tools.spies.feature.feature.group" version="0.18.0.v20200923-1237"/>
       <repository location="http://download.eclipse.org/e4/snapshots/org.eclipse.e4.tools/latest/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="com.opcoach.e4tester.feature.feature.group" version="1.1.0.202004072127"/>
-      <unit id="com.opcoach.e4.preferences.feature.feature.group" version="1.3.0.202004072127"/>
-      <repository location="https://www.opcoach.com/repository/2020-03"/>
+      <unit id="org.eclipse.equinox.sdk.feature.group" version="3.20.300.v20200828-1034"/>
+      <repository location="http://download.eclipse.org/eclipse/updates/4.17"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="com.opcoach.e4.preferences.feature.feature.group" version="1.3.0.202009281358"/>
+      <repository location="https://www.opcoach.com/repository/2020-09"/>
     </location>
   </locations>
 </target>

--- a/com.sii.rental.tp/com.sii.rental.tp.tpd
+++ b/com.sii.rental.tp/com.sii.rental.tp.tpd
@@ -1,7 +1,7 @@
 target "Training RCP 4" with source requirements
 
-// Update release to 2019-12
-location "http://download.eclipse.org/releases/2020-03" {
+// Update release to 2020-09
+location "http://download.eclipse.org/releases/2020-09" {
 	org.eclipse.platform.feature.group
 	org.eclipse.e4.rcp.feature.group
 	org.eclipse.emf.databinding.feature.group
@@ -18,12 +18,12 @@ location "http://download.eclipse.org/releases/2020-03" {
 	org.junit.jupiter.params
 	org.junit.platform.commons
 	
-}
+} 
 
 // Add support for java 11 (removed javax.annotation)...
-//location "https://download.eclipse.org/tools/orbit/downloads/drops/R20191126223242/repository" {
-//	javax.annotation
-//}
+location "https://download.eclipse.org/tools/orbit/downloads/drops/R20200831200620/repository" {
+	javax.annotation
+}
 
 location "http://download.eclipse.org/e4/snapshots/org.eclipse.e4.tools/latest/" {
 	org.eclipse.e4.tools.spies.feature.feature.group
@@ -31,14 +31,12 @@ location "http://download.eclipse.org/e4/snapshots/org.eclipse.e4.tools/latest/"
 
 
 // Add delta pack
-//location "http://download.eclipse.org/eclipse/updates/4.11" {
-//	org.eclipse.equinox.sdk.feature.group
-//}
+location "http://download.eclipse.org/eclipse/updates/4.17" {
+	org.eclipse.equinox.sdk.feature.group
+}
 
-// Add the new E4 test platform from opcoach website
-//location "https://dl.bintray.com/opcoach/E4Tester/" {
-location "https://www.opcoach.com/repository/2020-03" {
-   com.opcoach.e4tester.feature.feature.group
+// Add E4 Preferences
+location "https://www.opcoach.com/repository/2020-09" {
    com.opcoach.e4.preferences.feature.feature.group
 } 
 

--- a/com.sii.rental.ui.feature/.project
+++ b/com.sii.rental.ui.feature/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.sii.rental.ui.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/com.sii.rental.ui/.classpath
+++ b/com.sii.rental.ui/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-14"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/com.sii.rental.ui/.project
+++ b/com.sii.rental.ui/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.sii.rental.ui</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/com.sii.rental.ui/META-INF/MANIFEST.MF
+++ b/com.sii.rental.ui/META-INF/MANIFEST.MF
@@ -18,7 +18,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.e4.ui.services,
  com.opcoach.e4.preferences,
  org.eclipse.e4.core.di.extensions
-Bundle-RequiredExecutionEnvironment: JavaSE-14
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Import-Package: javax.annotation;version="1.0.0";resolution:=optional,
  javax.inject;version="1.0.0"

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,15 @@
 		<targetArtifact>com.sii.rental.tp</targetArtifact>
 		<targetVersion>4.17.0-SNAPSHOT</targetVersion>
 	</properties>
+	
+	<repositories>
+	<repository>
+        <id>2020-09</id>
+        <layout>p2</layout>
+        <url>http://download.eclipse.org/releases/2020-09</url>
+     </repository>
+	
+	</repositories>
 
 	<build>
 		<plugins>
@@ -88,8 +97,8 @@
 		<module>com.sii.rental.tp</module>
 		<module>com.sii.rental.core</module>
 		<module>com.sii.rental.ui</module>
-		<module>com.sii.rental.ui.feature</module>
 		<module>com.sii.rental.eap</module>
+		<module>com.sii.rental.ui.feature</module>
 		<module>com.sii.rental.repository</module>
 
 	</modules>


### PR DESCRIPTION
This pull request contains the fix for the delivery. 

Target platform had to be updated to 2020-09. (it was still on 2020-03).

Actually there is no 'osgi.ee' capability defined for java 14 in the latest target platform. This is why it was not working. Therefore all the plugins must be defined to work at least **with JavaSE-11** (and not JavaSE-14 as it was defined). 

Then, maven can be launched using the toolchain and the java 14 compiler. 

The result product is delivered in com.sii.rental.repository/target/products

